### PR TITLE
Ensure default academic period persists with id

### DIFF
--- a/public/js/global-period-selector.js
+++ b/public/js/global-period-selector.js
@@ -108,12 +108,42 @@ function buildDefaultPeriod() {
         schoolId = String(teacher.school_id);
     }
 
-    return {
+    const basePeriod = {
         schoolId,
         year: 2025,
         periodType: 'semester',
-        periodNumber: 1
+        periodNumber: 1,
+        periodId: null
     };
+
+    try {
+        const adminToken = localStorage.getItem('adminToken');
+        const sessionToken = localStorage.getItem('sessionToken');
+        const token = sessionToken || adminToken;
+
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', '/api/academic-periods/ensure', false);
+        if (token) {
+            xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+        }
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        xhr.send(JSON.stringify({
+            year: basePeriod.year,
+            period_type: basePeriod.periodType,
+            period_number: basePeriod.periodNumber
+        }));
+
+        if (xhr.status >= 200 && xhr.status < 300) {
+            const result = JSON.parse(xhr.responseText);
+            if (result.success && result.data && result.data.id) {
+                basePeriod.periodId = result.data.id;
+            }
+        }
+    } catch (err) {
+        console.error('Error obteniendo ID de período por defecto:', err);
+    }
+
+    return basePeriod;
 }
 
 class GlobalPeriodSelector {

--- a/server.js
+++ b/server.js
@@ -4334,6 +4334,30 @@ app.put('/api/academic-periods/:id/activate', authenticateAdmin, async (req, res
     }
 });
 
+// Obtener o crear un período académico y devolver su ID
+app.post('/api/academic-periods/ensure', authenticateAdminOrTeacher, async (req, res) => {
+    try {
+        const { year, period_type, period_number } = req.body;
+
+        if (!year || !period_type || !period_number) {
+            return res.status(400).json({
+                success: false,
+                message: 'Año, tipo de período y número son requeridos'
+            });
+        }
+
+        const id = await getOrCreateAcademicPeriodId(year, period_type, period_number);
+        res.json({ success: true, data: { id } });
+    } catch (error) {
+        console.error('Error asegurando período académico:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Error asegurando período académico',
+            error: error.message
+        });
+    }
+});
+
 // Obtener escuelas disponibles
 app.get('/api/schools', authenticateAdmin, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- add endpoint to obtain or create academic period id
- get period id when building default period on the client

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f7bb20e58832cb190d9e59639a86f